### PR TITLE
Added: option for excluding the default stylesheet. Fixed: add_framework_assets retrieval

### DIFF
--- a/blog-injector.php
+++ b/blog-injector.php
@@ -52,7 +52,10 @@ class BlogInjectorPlugin extends Plugin
             throw new \InvalidArgumentException(sprintf('The blog "framework" variable value must be one of "pure" or "bootstrap". You gave "%s"', $framework));
         }
 
-        $this->grav['assets']->add(sprintf('plugin://blog-injector/css/%s_blog.css', $framework));
+        if ($this->config->get('plugins.blog-injector.add_default_css')) {
+            $this->grav['assets']->add(sprintf('plugin://blog-injector/css/%s_blog.css', $framework));
+        }
+
         if ($this->config->get('plugins.blog-injector.add_framework_assets')) {
             $method = 'add' . ucfirst($framework);
             $this->$method();

--- a/blog-injector.php
+++ b/blog-injector.php
@@ -53,7 +53,7 @@ class BlogInjectorPlugin extends Plugin
         }
 
         $this->grav['assets']->add(sprintf('plugin://blog-injector/css/%s_blog.css', $framework));
-        if ($this->config->get('plugins.blog.add_framework_assets')) {
+        if ($this->config->get('plugins.blog-injector.add_framework_assets')) {
             $method = 'add' . ucfirst($framework);
             $this->$method();
         }

--- a/blog-injector.yaml
+++ b/blog-injector.yaml
@@ -1,3 +1,4 @@
 enabled: true
 framework: pure
+add_default_css: true
 add_framework_assets: true

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -45,6 +45,18 @@ form:
           bootstrap: bootstrap
         help: Choose the framework to use
 
+      add_default_css:
+        type: toggle
+        label: Add default stylesheet
+        highlight: 1
+        default: 1
+        options:
+          1: Enabled
+          0: Disabled
+        validate:
+          type: bool
+        help: Automatically adds the included blog stylesheet according to the selected framework, when true
+
       add_framework_assets:
         type: toggle
         label: Add framework assets


### PR DESCRIPTION
Hi,
since I'm currently developing a website using the blog-injector without using any of the bundled stylesheets, I've thought an option for disabling the inclusion of the default `bootstrap_blog.css` and `pure_blog.css` stylesheets in the header would be nice.

In addition, I've found a line of code which had not been changed according to the recent renaming of the plugin and fixed that as well.

Thanks for your work on this great plugin!
